### PR TITLE
Initial SwiftUI scaffolding

### DIFF
--- a/Sources/AppCore/AppState.swift
+++ b/Sources/AppCore/AppState.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+/// The mystical heartbeat of Buddy Beacon. Governs navigation and shared data.
+final class AppState: ObservableObject {
+    @Published var currentProfile: UserProfile?
+    @Published var currentMode: GameMode = .quickShuffle
+    @Published var revealedTask: Task?
+    @Published var showProfileSelection: Bool = false
+    @Published var showModeSelector: Bool = false
+}

--- a/Sources/AppCore/BuddyBeaconApp.swift
+++ b/Sources/AppCore/BuddyBeaconApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct BuddyBeaconApp: App {
+    @StateObject private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(appState)
+        }
+    }
+}

--- a/Sources/FizzleGoblin/FizzleGoblinEngine.swift
+++ b/Sources/FizzleGoblin/FizzleGoblinEngine.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Injects a spark of absurdity into everyday rituals.
+final class FizzleGoblinEngine {
+    func randomChaosTask() -> Task {
+        let chaosTasks = [
+            Task(title: "Goblin Stretch", prompt: "Wiggle every limb and grin at the nearest appliance.", category: .chaos, reward: "A ripple of laughter"),
+            Task(title: "Whisper to Water", prompt: "Sing a two-line ballad to your water glass.", category: .chaos, reward: nil)
+        ]
+        return chaosTasks.randomElement()!
+    }
+}

--- a/Sources/GameModes/GameMode.swift
+++ b/Sources/GameModes/GameMode.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Modes of play for Buddy Beacon quests.
+enum GameMode: String, CaseIterable, Identifiable {
+    case quickShuffle = "Quick Shuffle"
+    case challengeQuest = "Challenge Quest"
+    case fizzleGoblin = "Fizzle Goblin"
+
+    var id: String { rawValue }
+
+    /// Adjusts the tempo or flavor of tasks.
+    var description: String {
+        switch self {
+        case .quickShuffle:
+            return "Swift and breezy chores for a touch of daily sparkle."
+        case .challengeQuest:
+            return "Epic undertakings with timers and triumphs."
+        case .fizzleGoblin:
+            return "Chaotic antics from the realm of the Goblin."
+        }
+    }
+}

--- a/Sources/Lorekeeper/Lorekeeper.swift
+++ b/Sources/Lorekeeper/Lorekeeper.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// The Guardian voice shaping all narrative.
+struct Lorekeeper {
+    static func narrate(_ text: String) -> String {
+        "\u{2728} " + text + " \u{2728}"
+    }
+}

--- a/Sources/TaskEngine/Task.swift
+++ b/Sources/TaskEngine/Task.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// A single quest bestowed upon the player.
+struct Task: Identifiable {
+    let id = UUID()
+    let title: String
+    let prompt: String
+    let category: Category
+    let reward: String?
+
+    enum Category: String {
+        case cleaning, selfCare = "self-care", chaos
+    }
+}

--- a/Sources/TaskEngine/TaskEngine.swift
+++ b/Sources/TaskEngine/TaskEngine.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Conjures tasks using Gemma 3n (placeholder) and CoreML mood.
+final class TaskEngine {
+    /// Generates a whimsical task for the chosen mode.
+    func generateTask(for mode: GameMode) -> Task {
+        // Placeholder pool until Gemma 3n integration.
+        let tasks = [
+            Task(title: "Dust Dance", prompt: "Twirl with a feather duster and clear the cobwebs.", category: .cleaning, reward: "A shimmering high-five"),
+            Task(title: "Mirror Pep Talk", prompt: "Recite three compliments to yourself in the mirror.", category: .selfCare, reward: nil),
+            Task(title: "Sock Oracle", prompt: "Arrange three socks and whisper a secret to the cat.", category: .chaos, reward: "Goblin giggles")
+        ]
+        // Random selection for now
+        return tasks.randomElement()!
+    }
+}

--- a/Sources/UIViews/GameModeSelectorView.swift
+++ b/Sources/UIViews/GameModeSelectorView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct GameModeSelectorView: View {
+    @Binding var selectedMode: GameMode
+
+    var body: some View {
+        NavigationStack {
+            List(GameMode.allCases) { mode in
+                HStack {
+                    Text(mode.rawValue)
+                    Spacer()
+                    if selectedMode == mode {
+                        Image(systemName: "checkmark")
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { selectedMode = mode }
+            }
+            .navigationTitle("Game Mode")
+        }
+    }
+}
+
+struct GameModeSelectorView_Previews: PreviewProvider {
+    static var previews: some View {
+        GameModeSelectorView(selectedMode: .constant(.quickShuffle))
+    }
+}

--- a/Sources/UIViews/MainView.swift
+++ b/Sources/UIViews/MainView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct MainView: View {
+    var summonAction: () -> Void
+    var showProfiles: () -> Void
+    var showModes: () -> Void
+
+    var body: some View {
+        VStack(spacing: 40) {
+            Spacer()
+            Text("Buddy Beacon")
+                .font(.largeTitle)
+                .bold()
+            Button(action: summonAction) {
+                Text("Summon Task")
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .clipShape(Capsule())
+            }
+            .padding(.horizontal)
+            Spacer()
+            HStack {
+                Button("Profiles", action: showProfiles)
+                Spacer()
+                Button("Modes", action: showModes)
+            }
+            .padding(.horizontal)
+        }
+    }
+}
+
+struct MainView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainView(summonAction: {}, showProfiles: {}, showModes: {})
+    }
+}

--- a/Sources/UIViews/ProfileSelectionView.swift
+++ b/Sources/UIViews/ProfileSelectionView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct ProfileSelectionView: View {
+    let profiles: [UserProfile]
+    var onSelect: (UserProfile) -> Void
+
+    var body: some View {
+        NavigationStack {
+            List(profiles) { profile in
+                Button(action: { onSelect(profile) }) {
+                    HStack {
+                        Image(systemName: profile.avatarSystemImage)
+                        Text(profile.name)
+                    }
+                }
+            }
+            .navigationTitle("Choose Your Hero")
+        }
+    }
+}
+
+struct ProfileSelectionView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfileSelectionView(profiles: [UserProfile(name: "Alex", avatarSystemImage: "person")]) { _ in }
+    }
+}

--- a/Sources/UIViews/RootView.swift
+++ b/Sources/UIViews/RootView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject var appState: AppState
+    @StateObject private var profileStore = ProfileStore()
+    private let taskEngine = TaskEngine()
+    private let goblinEngine = FizzleGoblinEngine()
+
+    var body: some View {
+        NavigationStack {
+            MainView(
+                summonAction: summonTask,
+                showProfiles: { appState.showProfileSelection = true },
+                showModes: { appState.showModeSelector = true }
+            )
+                .navigationDestination(isPresented: Binding(
+                    get: { appState.revealedTask != nil },
+                    set: { if !$0 { appState.revealedTask = nil } })
+                ) {
+                    if let task = appState.revealedTask {
+                        TaskRevealView(task: task)
+                    }
+                }
+                .sheet(isPresented: $appState.showProfileSelection) {
+                    ProfileSelectionView(profiles: profileStore.profiles) { profile in
+                        appState.currentProfile = profile
+                    }
+                }
+                .sheet(isPresented: $appState.showModeSelector) {
+                    GameModeSelectorView(selectedMode: $appState.currentMode)
+                }
+        }
+    }
+
+    private func summonTask() {
+        switch appState.currentMode {
+        case .fizzleGoblin:
+            appState.revealedTask = goblinEngine.randomChaosTask()
+        default:
+            appState.revealedTask = taskEngine.generateTask(for: appState.currentMode)
+        }
+    }
+}
+
+struct RootView_Previews: PreviewProvider {
+    static var previews: some View {
+        RootView()
+            .environmentObject(AppState())
+    }
+}

--- a/Sources/UIViews/TaskRevealView.swift
+++ b/Sources/UIViews/TaskRevealView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct TaskRevealView: View {
+    let task: Task
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text(task.title)
+                .font(.title)
+                .bold()
+            Text(task.prompt)
+                .multilineTextAlignment(.center)
+            if let reward = task.reward {
+                Text("Reward: \(reward)")
+                    .italic()
+                    .padding(.top, 10)
+            }
+            Spacer()
+        }
+        .padding()
+        .animation(.easeInOut, value: task.id)
+    }
+}
+
+struct TaskRevealView_Previews: PreviewProvider {
+    static var previews: some View {
+        TaskRevealView(task: Task(title: "Sample", prompt: "Do the thing", category: .cleaning, reward: "Cookie"))
+    }
+}

--- a/Sources/UserProfiles/ProfileStore.swift
+++ b/Sources/UserProfiles/ProfileStore.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Temporary in-memory store for profiles until secure storage arrives.
+final class ProfileStore: ObservableObject {
+    @Published var profiles: [UserProfile] = [
+        UserProfile(name: "Alex", avatarSystemImage: "person.circle"),
+        UserProfile(name: "Sam", avatarSystemImage: "bolt.heart"),
+        UserProfile(name: "Riley", avatarSystemImage: "leaf")
+    ]
+}

--- a/Sources/UserProfiles/UserProfile.swift
+++ b/Sources/UserProfiles/UserProfile.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Represents a household hero using Buddy Beacon.
+struct UserProfile: Identifiable {
+    let id = UUID()
+    var name: String
+    var avatarSystemImage: String
+    var weighting: Int = 1
+}


### PR DESCRIPTION
## Summary
- set up `BuddyBeaconApp` with `AppState` and `RootView`
- define `GameMode` enum and simple task models
- add placeholder `TaskEngine` and `FizzleGoblinEngine`
- implement SwiftUI views: `MainView`, `TaskRevealView`, `ProfileSelectionView`, `GameModeSelectorView`
- include whimsical `Lorekeeper` helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860979d365883268ebedc0a560c16ca